### PR TITLE
feat: add soft delete to the timestamp

### DIFF
--- a/application/service/user_service.go
+++ b/application/service/user_service.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"fmt"
 	"fp-kpl/application/request"
 	"fp-kpl/application/response"
 	"fp-kpl/domain/refresh_token"
@@ -228,7 +227,6 @@ func (s *userService) Delete(ctx context.Context, userID string) error {
 	}
 
 	err = s.userRepository.Delete(ctx, tx, retrievedUser.ID.String())
-	err = fmt.Errorf("test error")
 	if err != nil {
 		return user.ErrorDeleteUser
 	}

--- a/domain/shared/timestamp.go
+++ b/domain/shared/timestamp.go
@@ -5,4 +5,5 @@ import "time"
 type Timestamp struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
+	DeletedAt *time.Time
 }

--- a/infrastructure/database/refresh_token/schema.go
+++ b/infrastructure/database/refresh_token/schema.go
@@ -5,19 +5,27 @@ import (
 	"fp-kpl/domain/refresh_token"
 	"fp-kpl/domain/shared"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 	"time"
 )
 
 type RefreshToken struct {
-	ID        uuid.UUID `gorm:"primaryKey;type:uuid;default:uuid_generate_v4();column:id"`
-	UserID    uuid.UUID `gorm:"type:uuid;not null;column:user_id"`
-	Token     string    `gorm:"type:varchar(255);not null;uniqueIndex;column:token"`
-	ExpiresAt time.Time `gorm:"type:timestamp with time zone;not null;column:expires_at"`
-	CreatedAt time.Time `gorm:"type:timestamp with time zone;column:created_at"`
-	UpdatedAt time.Time `gorm:"type:timestamp with time zone;column:updated_at"`
+	ID        uuid.UUID      `gorm:"primaryKey;type:uuid;default:uuid_generate_v4();column:id"`
+	UserID    uuid.UUID      `gorm:"type:uuid;not null;column:user_id"`
+	Token     string         `gorm:"type:varchar(255);not null;uniqueIndex;column:token"`
+	ExpiresAt time.Time      `gorm:"type:timestamp with time zone;not null;column:expires_at"`
+	CreatedAt time.Time      `gorm:"type:timestamp with time zone;column:created_at"`
+	UpdatedAt time.Time      `gorm:"type:timestamp with time zone;column:updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"type:timestamp with time zone;column:deleted_at"`
 }
 
 func EntityToSchema(entity refresh_token.RefreshToken) RefreshToken {
+	var deletedAtTime time.Time
+	if entity.DeletedAt != nil {
+		deletedAtTime = *entity.DeletedAt
+	} else {
+		deletedAtTime = time.Time{}
+	}
 	return RefreshToken{
 		ID:        entity.ID.ID,
 		UserID:    entity.UserID.ID,
@@ -25,6 +33,10 @@ func EntityToSchema(entity refresh_token.RefreshToken) RefreshToken {
 		ExpiresAt: entity.ExpiresAt,
 		CreatedAt: entity.CreatedAt,
 		UpdatedAt: entity.UpdatedAt,
+		DeletedAt: gorm.DeletedAt{
+			Time:  deletedAtTime,
+			Valid: entity.DeletedAt != nil,
+		},
 	}
 }
 
@@ -37,6 +49,7 @@ func SchemaToEntity(schema RefreshToken) refresh_token.RefreshToken {
 		Timestamp: shared.Timestamp{
 			CreatedAt: schema.CreatedAt,
 			UpdatedAt: schema.UpdatedAt,
+			DeletedAt: &schema.DeletedAt.Time,
 		},
 	}
 }

--- a/infrastructure/database/user/schema.go
+++ b/infrastructure/database/user/schema.go
@@ -5,23 +5,31 @@ import (
 	"fp-kpl/domain/shared"
 	"fp-kpl/domain/user"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 	"time"
 )
 
 type User struct {
-	ID          uuid.UUID `gorm:"type:uuid;primary_key;default:uuid_generate_v4();column:id"`
-	Name        string    `gorm:"type:varchar(100);not null;column:name"`
-	Email       string    `gorm:"type:varchar(255);uniqueIndex;not null;column:email"`
-	PhoneNumber string    `gorm:"type:varchar(20);index;column:phone_number"`
-	Password    string    `gorm:"type:varchar(255);not null;column:password"`
-	Role        string    `gorm:"type:varchar(50);not null;default:'user';column:role"`
-	ImageUrl    string    `gorm:"type:varchar(255);column:image_url"`
-	IsVerified  bool      `gorm:"default:false;column:is_verified"`
-	CreatedAt   time.Time `gorm:"type:timestamp with time zone;column:created_at"`
-	UpdatedAt   time.Time `gorm:"type:timestamp with time zone;column:updated_at"`
+	ID          uuid.UUID      `gorm:"type:uuid;primary_key;default:uuid_generate_v4();column:id"`
+	Name        string         `gorm:"type:varchar(100);not null;column:name"`
+	Email       string         `gorm:"type:varchar(255);uniqueIndex;not null;column:email"`
+	PhoneNumber string         `gorm:"type:varchar(20);index;column:phone_number"`
+	Password    string         `gorm:"type:varchar(255);not null;column:password"`
+	Role        string         `gorm:"type:varchar(50);not null;default:'user';column:role"`
+	ImageUrl    string         `gorm:"type:varchar(255);column:image_url"`
+	IsVerified  bool           `gorm:"default:false;column:is_verified"`
+	CreatedAt   time.Time      `gorm:"type:timestamp with time zone;column:created_at"`
+	UpdatedAt   time.Time      `gorm:"type:timestamp with time zone;column:updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"type:timestamp with time zone;column:deleted_at"`
 }
 
 func EntityToSchema(entity user.User) User {
+	var deletedAtTime time.Time
+	if entity.DeletedAt != nil {
+		deletedAtTime = *entity.DeletedAt
+	} else {
+		deletedAtTime = time.Time{}
+	}
 	return User{
 		ID:          entity.ID.ID,
 		Name:        entity.Name,
@@ -33,6 +41,10 @@ func EntityToSchema(entity user.User) User {
 		IsVerified:  entity.IsVerified,
 		CreatedAt:   entity.Timestamp.CreatedAt,
 		UpdatedAt:   entity.Timestamp.UpdatedAt,
+		DeletedAt: gorm.DeletedAt{
+			Time:  deletedAtTime,
+			Valid: entity.DeletedAt != nil,
+		},
 	}
 }
 
@@ -49,6 +61,7 @@ func SchemaToEntity(schema User) user.User {
 		Timestamp: shared.Timestamp{
 			CreatedAt: schema.CreatedAt,
 			UpdatedAt: schema.UpdatedAt,
+			DeletedAt: &schema.DeletedAt.Time,
 		},
 	}
 }


### PR DESCRIPTION
This pull request introduces soft delete functionality to the `User` and `RefreshToken` entities by adding a `DeletedAt` field and updating related schema mapping methods. Additionally, it removes an unused import and a redundant error assignment in the `userService` implementation.

### Soft Delete Implementation:

* [`domain/shared/timestamp.go`](diffhunk://#diff-5fe25f6a7881edd153c022471f74a0a81febda560b938cc3b00188007e4cb915R8): Added a `DeletedAt` field to the `Timestamp` struct to track soft deletion timestamps.
* `infrastructure/database/refresh_token/schema.go`: 
  - Added a `DeletedAt` field of type `gorm.DeletedAt` to the `RefreshToken` struct.
  - Updated `EntityToSchema` and `SchemaToEntity` methods to handle the new `DeletedAt` field. [[1]](diffhunk://#diff-4fccb19e1b5e690dbba6c91c1e2cf0c0842e0a8b3239fb8e5287d7624addcc21R19-R39) [[2]](diffhunk://#diff-4fccb19e1b5e690dbba6c91c1e2cf0c0842e0a8b3239fb8e5287d7624addcc21R52)
* `infrastructure/database/user/schema.go`: 
  - Added a `DeletedAt` field of type `gorm.DeletedAt` to the `User` struct.
  - Updated `EntityToSchema` and `SchemaToEntity` methods to handle the new `DeletedAt` field. [[1]](diffhunk://#diff-97e28115423f8cc39517c599ff54a7ab4c63a437238cb93d39d5dca328a85d53R44-R47) [[2]](diffhunk://#diff-97e28115423f8cc39517c599ff54a7ab4c63a437238cb93d39d5dca328a85d53R64)

### Code Cleanup:

* [`application/service/user_service.go`](diffhunk://#diff-3a3edbef18cbb0d9b5de3ee4a82537b1c411fb5178b0772f4faafc5cdcfc0291L6): Removed an unused `fmt` import and a redundant error assignment in the `Delete` method. [[1]](diffhunk://#diff-3a3edbef18cbb0d9b5de3ee4a82537b1c411fb5178b0772f4faafc5cdcfc0291L6) [[2]](diffhunk://#diff-3a3edbef18cbb0d9b5de3ee4a82537b1c411fb5178b0772f4faafc5cdcfc0291L231)

Closes #4 