### PR TITLE
fix: update TableNumber field to be unique in database schema

### DIFF
--- a/infrastructure/database/table/schema.go
+++ b/infrastructure/database/table/schema.go
@@ -12,7 +12,7 @@ import (
 
 type Table struct {
 	ID          uuid.UUID      `gorm:"type:uuid;primary_key;default:uuid_generate_v4();column:id"`
-	TableNumber string         `gorm:"type:varchar(255);not null;column:table_number"`
+	TableNumber string         `gorm:"type:varchar(255);unique;not null;column:table_number"`
 	CreatedAt   time.Time      `gorm:"type:timestamp with time zone;column:created_at"`
 	UpdatedAt   time.Time      `gorm:"type:timestamp with time zone;column:updated_at"`
 	DeletedAt   gorm.DeletedAt `gorm:"type:timestamp with time zone;column:deleted_at"`


### PR DESCRIPTION
This pull request includes a schema update to the `Table` model in the `infrastructure/database/table/schema.go` file. The change enforces a uniqueness constraint on the `TableNumber` field.

Database schema changes:

* [`infrastructure/database/table/schema.go`](diffhunk://#diff-63bf33338ead8690ede326d07a428cef9294cf2be5804d68a3d2795590177af3L15-R15): Updated the `TableNumber` field in the `Table` struct to include a `unique` constraint, ensuring that each table number is distinct in the database.