### PR TITLE
refactor: schema and repository in infrastructure

### DIFF
--- a/infrastructure/database/migration/data/table.go
+++ b/infrastructure/database/migration/data/table.go
@@ -1,8 +1,10 @@
 package data
 
-import "fp-kpl/infrastructure/database/table"
+import (
+	"fp-kpl/infrastructure/database/schema"
+)
 
-var Tables = []table.Table{
+var Tables = []schema.Table{
 	{
 		TableNumber: "01",
 	},

--- a/infrastructure/database/migration/migrate.go
+++ b/infrastructure/database/migration/migrate.go
@@ -1,16 +1,14 @@
 package migration
 
 import (
-	"fp-kpl/infrastructure/database/table"
-	"fp-kpl/infrastructure/database/user"
-
+	"fp-kpl/infrastructure/database/schema"
 	"gorm.io/gorm"
 )
 
 func Migrate(db *gorm.DB) error {
 	if err := db.AutoMigrate(
-		&user.User{},
-		&table.Table{},
+		&schema.User{},
+		&schema.Table{},
 	); err != nil {
 		return err
 	}

--- a/infrastructure/database/migration/seed/table.go
+++ b/infrastructure/database/migration/seed/table.go
@@ -2,15 +2,14 @@ package seed
 
 import (
 	"fp-kpl/infrastructure/database/migration/data"
-	"fp-kpl/infrastructure/database/table"
-
+	"fp-kpl/infrastructure/database/schema"
 	"gorm.io/gorm"
 )
 
 func Table(db *gorm.DB) error {
-	hasTable := db.Migrator().HasTable(&table.Table{})
+	hasTable := db.Migrator().HasTable(&schema.Table{})
 	if !hasTable {
-		return db.AutoMigrate(&table.Table{})
+		return db.AutoMigrate(&schema.Table{})
 	}
 
 	return db.CreateInBatches(data.Tables, 100).Error

--- a/infrastructure/database/repository/table.go
+++ b/infrastructure/database/repository/table.go
@@ -1,21 +1,22 @@
-package table
+package repository
 
 import (
 	"context"
 	"fp-kpl/domain/table"
 	"fp-kpl/infrastructure/database/db_transaction"
+	"fp-kpl/infrastructure/database/schema"
 	"fp-kpl/infrastructure/database/validation"
 )
 
-type repository struct {
+type tableRepository struct {
 	db *db_transaction.Repository
 }
 
-func NewRepository(db *db_transaction.Repository) table.Repository {
-	return &repository{db: db}
+func NewTableRepository(db *db_transaction.Repository) table.Repository {
+	return &tableRepository{db: db}
 }
 
-func (r *repository) GetAllTables(ctx context.Context, tx interface{}) ([]table.Table, error) {
+func (r *tableRepository) GetAllTables(ctx context.Context, tx interface{}) ([]table.Table, error) {
 	validatedTransaction, err := validation.ValidateTransaction(tx)
 	if err != nil {
 		return nil, err
@@ -26,22 +27,22 @@ func (r *repository) GetAllTables(ctx context.Context, tx interface{}) ([]table.
 		db = r.db.DB()
 	}
 
-	var tableSchemas []Table
+	var tableSchemas []schema.Table
 
-	query := db.WithContext(ctx).Model(&Table{})
+	query := db.WithContext(ctx).Model(&schema.Table{})
 	if err = query.Find(&tableSchemas).Error; err != nil {
 		return nil, err
 	}
 
 	tableEntities := make([]table.Table, len(tableSchemas))
 	for i, tableSchema := range tableSchemas {
-		tableEntities[i] = SchemaToEntity(tableSchema)
+		tableEntities[i] = schema.TableSchemaToEntity(tableSchema)
 	}
 
 	return tableEntities, nil
 }
 
-func (r *repository) GetTableByID(ctx context.Context, tx interface{}, id string) (table.Table, error) {
+func (r *tableRepository) GetTableByID(ctx context.Context, tx interface{}, id string) (table.Table, error) {
 	validatedTransaction, err := validation.ValidateTransaction(tx)
 	if err != nil {
 		return table.Table{}, err
@@ -52,12 +53,12 @@ func (r *repository) GetTableByID(ctx context.Context, tx interface{}, id string
 		db = r.db.DB()
 	}
 
-	var tableSchema Table
+	var tableSchema schema.Table
 
 	if err = db.WithContext(ctx).Where("id = ?", id).Take(&tableSchema).Error; err != nil {
 		return table.Table{}, err
 	}
 
-	tableEntity := SchemaToEntity(tableSchema)
+	tableEntity := schema.TableSchemaToEntity(tableSchema)
 	return tableEntity, nil
 }

--- a/infrastructure/database/repository/user.go
+++ b/infrastructure/database/repository/user.go
@@ -1,21 +1,22 @@
-package user
+package repository
 
 import (
 	"context"
 	"fp-kpl/domain/user"
 	"fp-kpl/infrastructure/database/db_transaction"
+	"fp-kpl/infrastructure/database/schema"
 	"fp-kpl/infrastructure/database/validation"
 )
 
-type repository struct {
+type userRepository struct {
 	db *db_transaction.Repository
 }
 
-func NewRepository(db *db_transaction.Repository) user.Repository {
-	return &repository{db: db}
+func NewUserRepository(db *db_transaction.Repository) user.Repository {
+	return &userRepository{db: db}
 }
 
-func (r *repository) Register(ctx context.Context, tx interface{}, userEntity user.User) (user.User, error) {
+func (r *userRepository) Register(ctx context.Context, tx interface{}, userEntity user.User) (user.User, error) {
 	validatedTransaction, err := validation.ValidateTransaction(tx)
 	if err != nil {
 		return user.User{}, err
@@ -26,16 +27,16 @@ func (r *repository) Register(ctx context.Context, tx interface{}, userEntity us
 		db = r.db.DB()
 	}
 
-	userSchema := EntityToSchema(userEntity)
+	userSchema := schema.UserEntityToSchema(userEntity)
 	if err = db.WithContext(ctx).Create(&userSchema).Error; err != nil {
 		return user.User{}, err
 	}
 
-	userEntity = SchemaToEntity(userSchema)
+	userEntity = schema.UserSchemaToEntity(userSchema)
 	return userEntity, nil
 }
 
-func (r *repository) GetUserByID(ctx context.Context, tx interface{}, id string) (user.User, error) {
+func (r *userRepository) GetUserByID(ctx context.Context, tx interface{}, id string) (user.User, error) {
 	validatedTransaction, err := validation.ValidateTransaction(tx)
 	if err != nil {
 		return user.User{}, err
@@ -46,16 +47,16 @@ func (r *repository) GetUserByID(ctx context.Context, tx interface{}, id string)
 		db = r.db.DB()
 	}
 
-	var userSchema User
+	var userSchema schema.User
 	if err = db.WithContext(ctx).Where("id = ?", id).Take(&userSchema).Error; err != nil {
 		return user.User{}, err
 	}
 
-	userEntity := SchemaToEntity(userSchema)
+	userEntity := schema.UserSchemaToEntity(userSchema)
 	return userEntity, nil
 }
 
-func (r *repository) GetUserByEmail(ctx context.Context, tx interface{}, email string) (user.User, error) {
+func (r *userRepository) GetUserByEmail(ctx context.Context, tx interface{}, email string) (user.User, error) {
 	validatedTransaction, err := validation.ValidateTransaction(tx)
 	if err != nil {
 		return user.User{}, err
@@ -66,16 +67,16 @@ func (r *repository) GetUserByEmail(ctx context.Context, tx interface{}, email s
 		db = r.db.DB()
 	}
 
-	var userSchema User
+	var userSchema schema.User
 	if err = db.WithContext(ctx).Where("email = ?", email).Take(&userSchema).Error; err != nil {
 		return user.User{}, err
 	}
 
-	userEntity := SchemaToEntity(userSchema)
+	userEntity := schema.UserSchemaToEntity(userSchema)
 	return userEntity, nil
 }
 
-func (r *repository) CheckEmail(ctx context.Context, tx interface{}, email string) (user.User, bool, error) {
+func (r *userRepository) CheckEmail(ctx context.Context, tx interface{}, email string) (user.User, bool, error) {
 	validatedTransaction, err := validation.ValidateTransaction(tx)
 	if err != nil {
 		return user.User{}, false, err
@@ -86,11 +87,11 @@ func (r *repository) CheckEmail(ctx context.Context, tx interface{}, email strin
 		db = r.db.DB()
 	}
 
-	var userSchema User
+	var userSchema schema.User
 	if err = db.WithContext(ctx).Where("email = ?", email).Take(&userSchema).Error; err != nil {
 		return user.User{}, false, err
 	}
 
-	userEntity := SchemaToEntity(userSchema)
+	userEntity := schema.UserSchemaToEntity(userSchema)
 	return userEntity, true, nil
 }

--- a/infrastructure/database/schema/table.go
+++ b/infrastructure/database/schema/table.go
@@ -1,4 +1,4 @@
-package table
+package schema
 
 import (
 	"fp-kpl/domain/identity"
@@ -18,7 +18,7 @@ type Table struct {
 	DeletedAt   gorm.DeletedAt `gorm:"type:timestamp with time zone;column:deleted_at"`
 }
 
-func EntityToSchema(entity table.Table) Table {
+func TableEntityToSchema(entity table.Table) Table {
 	var deletedAtTime time.Time
 	if entity.DeletedAt != nil {
 		deletedAtTime = *entity.DeletedAt
@@ -37,7 +37,7 @@ func EntityToSchema(entity table.Table) Table {
 	}
 }
 
-func SchemaToEntity(schema Table) table.Table {
+func TableSchemaToEntity(schema Table) table.Table {
 	return table.Table{
 		ID:          identity.NewIDFromSchema(schema.ID),
 		TableNumber: schema.TableNumber,

--- a/infrastructure/database/schema/user.go
+++ b/infrastructure/database/schema/user.go
@@ -1,4 +1,4 @@
-package user
+package schema
 
 import (
 	"fp-kpl/domain/identity"
@@ -23,7 +23,7 @@ type User struct {
 	DeletedAt   gorm.DeletedAt `gorm:"type:timestamp with time zone;column:deleted_at"`
 }
 
-func EntityToSchema(entity user.User) User {
+func UserEntityToSchema(entity user.User) User {
 	var deletedAtTime time.Time
 	if entity.DeletedAt != nil {
 		deletedAtTime = *entity.DeletedAt
@@ -46,7 +46,7 @@ func EntityToSchema(entity user.User) User {
 	}
 }
 
-func SchemaToEntity(schema User) user.User {
+func UserSchemaToEntity(schema User) user.User {
 	return user.User{
 		ID:          identity.NewIDFromSchema(schema.ID),
 		Email:       schema.Email,

--- a/main.go
+++ b/main.go
@@ -5,8 +5,7 @@ import (
 	"fp-kpl/command"
 	"fp-kpl/infrastructure/database/config"
 	"fp-kpl/infrastructure/database/db_transaction"
-	infrastructure_table "fp-kpl/infrastructure/database/table"
-	infrastructure_user "fp-kpl/infrastructure/database/user"
+	"fp-kpl/infrastructure/database/repository"
 	"fp-kpl/presentation/controller"
 	"fp-kpl/presentation/middleware"
 	"fp-kpl/presentation/route"
@@ -53,10 +52,10 @@ func main() {
 	db := config.SetUpDatabaseConnection()
 
 	jwtService := service.NewJWTService()
-
 	transactionRepository := db_transaction.NewRepository(db)
-	userRepository := infrastructure_user.NewRepository(transactionRepository)
-	tableRepository := infrastructure_table.NewRepository(transactionRepository)
+
+	userRepository := repository.NewUserRepository(transactionRepository)
+	tableRepository := repository.NewTableRepository(transactionRepository)
 
 	userService := service.NewUserService(userRepository, jwtService, transactionRepository)
 	tableService := service.NewTableService(tableRepository)


### PR DESCRIPTION
This pull request refactors the database layer by consolidating schema-related logic into a unified `schema` package and renaming files and types for clarity. It also updates repository implementations to align with the new schema package and improves naming conventions for repository types and methods. 

### Schema Refactoring:
* Consolidated all schema-related logic into a new `schema` package, replacing the previous `table` and `user` packages. Updated imports and type references across multiple files to reflect this change. (`[[1]](diffhunk://#diff-da70ec4faa997c34a800624ce425bfe91acfbdfab567154b504705e0f0c6fa7eL3-R7)`, `[[2]](diffhunk://#diff-ad314711093f243297ae65b85cb4e23ea60cb518aa966fe8a774c20449df0caeL4-R11)`, `[[3]](diffhunk://#diff-a5dd80e6ce5bb88a0bd30d0e1e93bf527d06a0c7a79d8c0758b15aca9e03426bL5-R12)`, `[[4]](diffhunk://#diff-ba15feed94bbdbc9762638d98c98ed14af845f02ae2b93fc150866a527774320L29-R45)`, `[[5]](diffhunk://#diff-ba15feed94bbdbc9762638d98c98ed14af845f02ae2b93fc150866a527774320L55-R62)`, `[[6]](diffhunk://#diff-d77ba2284ee5d5677cb74ba1e22c16597434ca234ff1b958a5ca8497a73cc1ecL29-R39)`, `[[7]](diffhunk://#diff-d77ba2284ee5d5677cb74ba1e22c16597434ca234ff1b958a5ca8497a73cc1ecL49-R59)`, `[[8]](diffhunk://#diff-d77ba2284ee5d5677cb74ba1e22c16597434ca234ff1b958a5ca8497a73cc1ecL69-R79)`, `[[9]](diffhunk://#diff-d77ba2284ee5d5677cb74ba1e22c16597434ca234ff1b958a5ca8497a73cc1ecL89-R95)`, `[[10]](diffhunk://#diff-4af2a762f06857291fffb5ee71b6738b08ecbcaed67b200d6159de3aab58ba3fL21-R21)`, `[[11]](diffhunk://#diff-4af2a762f06857291fffb5ee71b6738b08ecbcaed67b200d6159de3aab58ba3fL40-R40)`, `[[12]](diffhunk://#diff-c68ec13eff37c1eff8c69608d24df839fea42a053d2052982126ab91a3280e03L26-R26)`, `[[13]](diffhunk://#diff-c68ec13eff37c1eff8c69608d24df839fea42a053d2052982126ab91a3280e03L49-R49)`)

### Repository Improvements:
* Renamed repository files to `repository` package for better organization and clarity. Updated repository struct and method names to reflect the entity they manage (e.g., `tableRepository`, `userRepository`). (`[[1]](diffhunk://#diff-ba15feed94bbdbc9762638d98c98ed14af845f02ae2b93fc150866a527774320L1-R19)`, `[[2]](diffhunk://#diff-d77ba2284ee5d5677cb74ba1e22c16597434ca234ff1b958a5ca8497a73cc1ecL1-R19)`)

### Application Updates:
* Updated `main.go` to use the new repository constructors (`NewUserRepository` and `NewTableRepository`) from the `repository` package. (`[[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L8-R8)`, `[[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L56-R58)`)