### PR TITLE
feat: implement order repository with methods for creating orders and retrieving orders by transaction ID

### DIFF
--- a/domain/order/repository.go
+++ b/domain/order/repository.go
@@ -5,9 +5,6 @@ import "context"
 type (
 	Repository interface {
 		CreateOrder(ctx context.Context, tx interface{}, orderEntity Order) (Order, error)
-		GetAllOrder(ctx context.Context, tx interface{}) ([]Order, error)
-		GetOrderByID(ctx context.Context, tx interface{}, id string) (Order, error)
 		GetOrderByTransactionID(ctx context.Context, tx interface{}, transactionID string) ([]Order, error)
-		UpdateOrder(ctx context.Context, tx interface{}, orderEntity Order) (Order, error)
 	}
 )

--- a/infrastructure/database/repository/order.go
+++ b/infrastructure/database/repository/order.go
@@ -1,0 +1,61 @@
+package repository
+
+import (
+	"context"
+	"fp-kpl/domain/order"
+	"fp-kpl/infrastructure/database/db_transaction"
+	"fp-kpl/infrastructure/database/schema"
+	"fp-kpl/infrastructure/database/validation"
+)
+
+type orderRepository struct {
+	db *db_transaction.Repository
+}
+
+func NewOrderRepository(db *db_transaction.Repository) order.Repository {
+	return &orderRepository{db: db}
+}
+
+func (r *orderRepository) CreateOrder(ctx context.Context, tx interface{}, orderEntity order.Order) (order.Order, error) {
+	validatedTransaction, err := validation.ValidateTransaction(tx)
+	if err != nil {
+		return order.Order{}, err
+	}
+
+	db := validatedTransaction.DB()
+	if db == nil {
+		db = r.db.DB()
+	}
+
+	orderSchema := schema.OrderEntityToSchema(orderEntity)
+	if err = db.WithContext(ctx).Create(&orderSchema).Error; err != nil {
+		return order.Order{}, err
+	}
+
+	orderEntity = schema.OrderSchemaToEntity(orderSchema)
+	return orderEntity, nil
+}
+
+func (r *orderRepository) GetOrderByTransactionID(ctx context.Context, tx interface{}, transactionID string) ([]order.Order, error) {
+	validatedTransaction, err := validation.ValidateTransaction(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	db := validatedTransaction.DB()
+	if db == nil {
+		db = r.db.DB()
+	}
+
+	var orderSchemas []schema.Order
+	if err = db.WithContext(ctx).Where("transaction_id = ?", transactionID).Find(&orderSchemas).Error; err != nil {
+		return nil, err
+	}
+
+	orderEntities := make([]order.Order, len(orderSchemas))
+	for i, orderSchema := range orderSchemas {
+		orderEntities[i] = schema.OrderSchemaToEntity(orderSchema)
+	}
+
+	return orderEntities, nil
+}


### PR DESCRIPTION
This pull request refactors the `order` repository by removing unused methods from the `Repository` interface and implementing the remaining methods in a new concrete repository struct. The changes aim to streamline the repository interface and improve database interaction.

### Repository Interface Refactoring:

* Removed unused methods `GetAllOrder`, `GetOrderByID`, and `UpdateOrder` from the `Repository` interface in `domain/order/repository.go` to simplify the interface.

### Implementation of Repository Methods:

* Added a new `orderRepository` struct in `infrastructure/database/repository/order.go` to implement the `CreateOrder` and `GetOrderByTransactionID` methods from the `Repository` interface.
  - The `CreateOrder` method validates the transaction, converts the order entity to a database schema, persists it, and converts it back to an entity.
  - The `GetOrderByTransactionID` method retrieves orders by `transaction_id`, maps the database schemas to order entities, and returns them.