### PR TITLE
fix: correct Duration value method to return valid PostgreSQL interval format

### DIFF
--- a/infrastructure/database/schema/menu.go
+++ b/infrastructure/database/schema/menu.go
@@ -39,7 +39,17 @@ func (d *Duration) Scan(value interface{}) error {
 }
 
 func (d Duration) Value() (driver.Value, error) {
-	return d.Duration.Nanoseconds(), nil
+	// Convert to PostgreSQL interval format instead of nanoseconds
+	// Format: HH:MM:SS or HH:MM:SS.microseconds
+	hours := int(d.Duration.Hours())
+	minutes := int(d.Duration.Minutes()) % 60
+	seconds := int(d.Duration.Seconds()) % 60
+	microseconds := int(d.Duration.Microseconds()) % 1000000
+
+	if microseconds > 0 {
+		return fmt.Sprintf("%02d:%02d:%02d.%06d", hours, minutes, seconds, microseconds), nil
+	}
+	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds), nil
 }
 
 func (d *Duration) parseInterval(interval string) error {


### PR DESCRIPTION
This pull request updates the `Value` method in the `Duration` struct to improve compatibility with PostgreSQL by converting durations into the PostgreSQL interval format instead of returning nanoseconds.

### Changes to PostgreSQL compatibility:

* [`infrastructure/database/schema/menu.go`](diffhunk://#diff-8375f4dea32ad743f09de5c652ab36eb7121db914f4a29b6d40342aae3abd361L42-R52): Updated the `Value` method in the `Duration` struct to return a formatted string in PostgreSQL interval format (`HH:MM:SS` or `HH:MM:SS.microseconds`) instead of nanoseconds. This ensures better compatibility with PostgreSQL databases.