### PR TITLE
feat: add conflict handling for batch creation in category, menu, and table seeders

### DIFF
--- a/infrastructure/database/migration/seed/category.go
+++ b/infrastructure/database/migration/seed/category.go
@@ -5,6 +5,7 @@ import (
 	"fp-kpl/infrastructure/database/schema"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func Category(db *gorm.DB) error {
@@ -13,5 +14,8 @@ func Category(db *gorm.DB) error {
 		return db.AutoMigrate(&schema.Category{})
 	}
 
-	return db.CreateInBatches(data.Categories, 100).Error
+	return db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "name"}},
+		DoNothing: true,
+	}).CreateInBatches(data.Categories, 100).Error
 }

--- a/infrastructure/database/migration/seed/menu.go
+++ b/infrastructure/database/migration/seed/menu.go
@@ -5,6 +5,7 @@ import (
 	"fp-kpl/infrastructure/database/schema"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func Menu(db *gorm.DB) error {
@@ -15,5 +16,8 @@ func Menu(db *gorm.DB) error {
 
 	menus := data.GetMenus(db)
 
-	return db.CreateInBatches(menus, 100).Error
+	return db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "name"}},
+		DoNothing: true,
+	}).CreateInBatches(menus, 100).Error
 }

--- a/infrastructure/database/migration/seed/table.go
+++ b/infrastructure/database/migration/seed/table.go
@@ -3,7 +3,9 @@ package seed
 import (
 	"fp-kpl/infrastructure/database/migration/data"
 	"fp-kpl/infrastructure/database/schema"
+
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func Table(db *gorm.DB) error {
@@ -12,5 +14,8 @@ func Table(db *gorm.DB) error {
 		return db.AutoMigrate(&schema.Table{})
 	}
 
-	return db.CreateInBatches(data.Tables, 100).Error
+	return db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "table_number"}},
+		DoNothing: true,
+	}).CreateInBatches(data.Tables, 100).Error
 }


### PR DESCRIPTION
This pull request introduces changes to the database seeding logic to handle conflicts more gracefully by using the `gorm.io/gorm/clause` package's `OnConflict` clause. The updates ensure that duplicate entries are ignored during batch creation in the `Category`, `Menu`, and `Table` seed functions.

### Enhancements to conflict handling in database seeding:

* **`Category` seeding (`category.go`)**: Added `clause.OnConflict` to ignore duplicate entries based on the `name` column when seeding categories.
* **`Menu` seeding (`menu.go`)**: Added `clause.OnConflict` to ignore duplicate entries based on the `id` column when seeding menus.
* **`Table` seeding (`table.go`)**: Added `clause.OnConflict` to ignore duplicate entries based on the `table_number` column when seeding tables.

### Dependency updates:

* Added the `gorm.io/gorm/clause` package to the import statements in `category.go`, `menu.go`, and `table.go` to support the `OnConflict` functionality. [[1]](diffhunk://#diff-626a29839fc58a92257637e7c67f759f887e5f5aff2ca21d85f98d064de36ea8R8) [[2]](diffhunk://#diff-0153f0331ab1680a560da0468256b42b7a049504650d816efc4e6b471f7e3d89R8) [[3]](diffhunk://#diff-a5dd80e6ce5bb88a0bd30d0e1e93bf527d06a0c7a79d8c0758b15aca9e03426bR6-R8)