### PR TITLE
fix: update menu availability request to use pointer for IsAvailable field

### DIFF
--- a/application/request/menu.go
+++ b/application/request/menu.go
@@ -2,6 +2,6 @@ package request
 
 type (
 	UpdateMenuAvailabilityRequest struct {
-		IsAvailable bool `json:"is_available" form:"is_available" binding:"required"`
+		IsAvailable *bool `json:"is_available" form:"is_available" binding:"required"`
 	}
 )

--- a/presentation/controller/menu.go
+++ b/presentation/controller/menu.go
@@ -85,7 +85,13 @@ func (c *menuController) UpdateMenuAvailability(ctx *gin.Context) {
 		return
 	}
 
-	responseMenu, err := c.menuService.UpdateMenuAvailability(ctx.Request.Context(), id, req.IsAvailable)
+	if req.IsAvailable == nil {
+		res := presentation.BuildResponseFailed(message.FailedGetDataFromBody, "Field is_available is required", nil)
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, res)
+		return
+	}
+
+	responseMenu, err := c.menuService.UpdateMenuAvailability(ctx.Request.Context(), id, *req.IsAvailable)
 	if err != nil {
 		if errors.Is(err, menu.ErrorMenuNotFound) {
 			res := presentation.BuildResponseFailed(message.FailedUpdateMenuAvailability, err.Error(), nil)


### PR DESCRIPTION
This pull request introduces a change to how menu availability is handled by updating the `IsAvailable` field in the `UpdateMenuAvailabilityRequest` struct to use a pointer type. This ensures that the field can explicitly represent a `nil` value, allowing for better differentiation between "not provided" and "false." Corresponding updates were made to the controller logic to dereference the pointer when passing the value.

### Changes to request handling:

* [`application/request/menu.go`](diffhunk://#diff-9f026d68dee72989cd953b5451e11e3b054e0548f3e41e81de729d9cde79de1fL5-R5): Updated the `IsAvailable` field in the `UpdateMenuAvailabilityRequest` struct from `bool` to `*bool` to allow for `nil` values, improving flexibility in handling optional fields.

### Changes to controller logic:

* [`presentation/controller/menu.go`](diffhunk://#diff-4e7a0911f9e017c2117dadb14765666a9c1647030502ca181a87b712fad7ff2cL88-R88): Modified the `UpdateMenuAvailability` method to dereference the `IsAvailable` pointer before passing it to the service layer, ensuring compatibility with the updated request struct.