### PR TITLE
feat: implement queue code and payment code

### DIFF
--- a/domain/transaction/queue_code.go
+++ b/domain/transaction/queue_code.go
@@ -26,7 +26,7 @@ func NewQueueCodeFromSchema(code string, valid bool) QueueCode {
 
 func (q *QueueCode) QueueNumber() (int, error) {
 	number := strings.TrimPrefix(q.Code, "Q")
-	if number == "0000" {
+	if number == "0000" || number == "" {
 		return 0, nil
 	}
 	var queueNumber int

--- a/domain/transaction/repository.go
+++ b/domain/transaction/repository.go
@@ -8,6 +8,6 @@ type Repository interface {
 	CreateTransaction(ctx context.Context, tx interface{}, transactionEntity Transaction) (Transaction, error)
 	GetAllTransactions(ctx context.Context, tx interface{}) ([]Transaction, error)
 	GetTransactionByID(ctx context.Context, tx interface{}, id string) (Transaction, error)
-	GetLatestQueueCode(ctx context.Context, tx interface{}) (QueueCode, error)
+	GetLatestQueueCode(ctx context.Context, tx interface{}, id string) (string, error)
 	UpdateTransaction(ctx context.Context, tx interface{}, transactionEntity Transaction) (Transaction, error)
 }

--- a/domain/transaction/service.go
+++ b/domain/transaction/service.go
@@ -2,12 +2,13 @@ package transaction
 
 import (
 	"context"
+
 	"fmt"
 )
 
 type (
 	Service interface {
-		GenerateQueueCode(ctx context.Context) (string, error)
+		GenerateQueueCode(ctx context.Context, transactionID string) (string, error)
 	}
 
 	service struct {
@@ -21,17 +22,11 @@ func NewService(transactionRepository Repository) Service {
 	}
 }
 
-func (s *service) GenerateQueueCode(ctx context.Context) (string, error) {
-	latestCode, err := s.transactionRepository.GetLatestQueueCode(ctx, nil)
+func (s *service) GenerateQueueCode(ctx context.Context, transactionID string) (string, error) {
+	latestCode, err := s.transactionRepository.GetLatestQueueCode(ctx, nil, transactionID)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get latest queue code: %w", err)
 	}
 
-	numericLatestCode, err := latestCode.QueueNumber()
-	if err != nil {
-		return "", err
-	}
-
-	newCodeString := fmt.Sprintf("Q%04d", numericLatestCode+1)
-	return newCodeString, nil
+	return latestCode, nil
 }

--- a/infrastructure/adapter/payment_gateway/midtrans.go
+++ b/infrastructure/adapter/payment_gateway/midtrans.go
@@ -118,10 +118,12 @@ func (m midtransAdapter) HookPayment(ctx context.Context, tx interface{}, transa
 	}
 
 	transactionData.PaymentStatus = status
-	transactionData.PaymentCode = datas["status_code"].(string)
+	transactionData.PaymentCode = datas["transaction_id"].(string)
 
-	// TODO: Replace with actual queue code logic
-	queueCode := "xxx123"
+	queueCode, err := m.transactionDomainService.GenerateQueueCode(ctx, transactionData.ID.String())
+	if err != nil {
+		return fmt.Errorf("failed to generate queue code: %w", err)
+	}
 
 	err = db.WithContext(ctx).
 		Model(&transactionData).


### PR DESCRIPTION
This pull request refactors the queue code generation logic in the transaction domain. The changes streamline the process by introducing transaction-specific queue code generation, ensuring unique queue codes per transaction, and updating related interfaces and methods accordingly.

### Queue Code Generation Updates:
* [`domain/transaction/queue_code.go`](diffhunk://#diff-428762ed2fed91aa2f070d3e3c2dad9f51d10d6883e40f656b8c0bff785cf6f1L29-R29): Modified `QueueNumber` method to handle empty queue codes gracefully by returning `0`.
* [`domain/transaction/repository.go`](diffhunk://#diff-7595c3661860df61edbb833a461f225b40b12578a393228272490733c9839f86L11-R11): Updated `GetLatestQueueCode` method to accept a transaction ID and return a string instead of a `QueueCode` object.
* [`domain/transaction/service.go`](diffhunk://#diff-765ed1189b2fc6559784d156b90c4cf6313d35c19a9394f8017373f2540af6dcR5-R11): Refactored `GenerateQueueCode` method to include transaction-specific logic and return the latest queue code directly. [[1]](diffhunk://#diff-765ed1189b2fc6559784d156b90c4cf6313d35c19a9394f8017373f2540af6dcR5-R11) [[2]](diffhunk://#diff-765ed1189b2fc6559784d156b90c4cf6313d35c19a9394f8017373f2540af6dcL24-R31)

### Integration with Payment Gateway:
* [`infrastructure/adapter/payment_gateway/midtrans.go`](diffhunk://#diff-7c713a22b01bbbc670ede12245034ea2379482339f4896e5fb3b0851c883733cL121-R126): Updated `HookPayment` method to use the new `GenerateQueueCode` logic, ensuring queue codes are tied to specific transactions.

### Database Repository Enhancements:
* [`infrastructure/database/repository/transaction.go`](diffhunk://#diff-71f0bbd63b1a65be3ca705b3b9db040b7211face54b12779f23c4ddcae49e994L87-R94): Enhanced `GetLatestQueueCode` logic to filter by date and exclude the current transaction ID, ensuring unique queue codes. Added fallback logic to generate the first queue code if none exist. [[1]](diffhunk://#diff-71f0bbd63b1a65be3ca705b3b9db040b7211face54b12779f23c4ddcae49e994L87-R94) [[2]](diffhunk://#diff-71f0bbd63b1a65be3ca705b3b9db040b7211face54b12779f23c4ddcae49e994R103-R123)