### PR TITLE
ci: add workflow for automated deployment on main branch push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Auto Pull and Build
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Copy, Build, Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execute remote SSH commands using password
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}
+          script: |
+            cd /fp-kpl-be
+            git checkout main
+            git fetch --all --prune
+            git pull --rebase origin main
+            go build main.go
+            sudo systemctl stop goweb
+            sudo systemctl daemon-reexec
+            sudo systemctl daemon-reload
+            sudo systemctl start goweb
+            sudo systemctl status goweb


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment process for the project. The workflow is triggered by pushes to the `main` branch and includes steps for pulling the latest code, building the project, and restarting the service.

### Deployment Automation:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R29): Added a new workflow named "Auto Pull and Build" that triggers on pushes to the `main` branch. It uses the `appleboy/ssh-action` to execute remote SSH commands for fetching, building, and deploying the application, as well as restarting the `goweb` service.