### PR TITLE
feat: update ProcessPayment to return  token and payment link

### DIFF
--- a/application/response/transaction.go
+++ b/application/response/transaction.go
@@ -6,6 +6,7 @@ type (
 	TransactionCreate struct {
 		TransactionID string                      `json:"transaction_id" form:"transaction_id" binding:"required"`
 		TotalPrice    string                      `json:"total_price" form:"total_price" binding:"required"`
+		Token         string                      `json:"token" form:"token" binding:"required"`
 		PaymentLink   string                      `json:"payment_link" form:"payment_link" binding:"required"`
 		Orders        []OrderForTransactionCreate `json:"orders" form:"orders" binding:"required"`
 	}

--- a/application/service/transaction_service.go
+++ b/application/service/transaction_service.go
@@ -145,7 +145,7 @@ func (s *transactionService) CreateTransaction(ctx context.Context, userID strin
 		})
 	}
 
-	paymentURL, err := s.paymentGatewayPort.ProcessPayment(ctx, tx, createdTransaction)
+	payment, err := s.paymentGatewayPort.ProcessPayment(ctx, tx, createdTransaction)
 	if err != nil {
 		return response.TransactionCreate{}, err
 	}
@@ -153,7 +153,8 @@ func (s *transactionService) CreateTransaction(ctx context.Context, userID strin
 	return response.TransactionCreate{
 		TransactionID: createdTransaction.ID.String(),
 		TotalPrice:    totalPrice.Price.String(),
-		PaymentLink:   paymentURL,
+		Token:         payment.Token,
+		PaymentLink:   payment.PaymentLink,
 		Orders:        createdOrders,
 	}, nil
 }

--- a/domain/port/payment_gateway.go
+++ b/domain/port/payment_gateway.go
@@ -8,7 +8,12 @@ import (
 
 type (
 	PaymentGatewayPort interface {
-		ProcessPayment(ctx context.Context, tx interface{}, transactionEntity transaction.Transaction) (string, error)
+		ProcessPayment(ctx context.Context, tx interface{}, transactionEntity transaction.Transaction) (ProcessPaymentResponse, error)
 		HookPayment(ctx context.Context, tx interface{}, transactionId uuid.UUID, datas map[string]interface{}) error
+	}
+
+	ProcessPaymentResponse struct {
+		Token       string
+		PaymentLink string
 	}
 )


### PR DESCRIPTION
This pull request introduces changes to the payment processing flow to include a `Token` field in addition to the `PaymentLink`. It updates the `ProcessPayment` method to return a structured response (`ProcessPaymentResponse`) instead of a single string, ensuring better encapsulation of payment-related data.

### Updates to the payment processing flow:

* **Addition of `Token` field**:
  - Modified the `TransactionCreate` struct in `application/response/transaction.go` to include a new `Token` field for storing payment tokens.
  - Updated the `CreateTransaction` method in `application/service/transaction_service.go` to populate the `Token` field from the payment gateway response.

* **Refactoring of `ProcessPayment` method**:
  - Updated the `PaymentGatewayPort` interface in `domain/port/payment_gateway.go` to return a `ProcessPaymentResponse` struct containing both `Token` and `PaymentLink`.
  - Refactored the `ProcessPayment` implementation in `infrastructure/adapter/payment_gateway/midtrans.go` to construct and return the `ProcessPaymentResponse` struct. [[1]](diffhunk://#diff-7c713a22b01bbbc670ede12245034ea2379482339f4896e5fb3b0851c883733cL31-R34) [[2]](diffhunk://#diff-7c713a22b01bbbc670ede12245034ea2379482339f4896e5fb3b0851c883733cL50-R50) [[3]](diffhunk://#diff-7c713a22b01bbbc670ede12245034ea2379482339f4896e5fb3b0851c883733cL85-R90)