### PR TITLE
feat: add GetNextOrder endpoint to retrieve the next order for a kitchen

### DIFF
--- a/application/response/transaction.go
+++ b/application/response/transaction.go
@@ -37,4 +37,9 @@ type (
 		Menu     MenuForTransaction `json:"menu" form:"menu" binding:"required"`
 		Quantity int                `json:"quantity" form:"quantity" binding:"required"`
 	}
+
+	NextOrder struct {
+		QueueCode string                `json:"queue_code" form:"queue_code" binding:"required"`
+		Orders    []OrderForTransaction `json:"orders" form:"orders" binding:"required"`
+	}
 )

--- a/domain/transaction/repository.go
+++ b/domain/transaction/repository.go
@@ -11,4 +11,5 @@ type Repository interface {
 	GetTransactionByID(ctx context.Context, tx interface{}, userID string, id string) (interface{}, error)
 	GetLatestQueueCode(ctx context.Context, tx interface{}, id string) (string, error)
 	UpdateTransaction(ctx context.Context, tx interface{}, transactionEntity Transaction) (Transaction, error)
+	GetNextOrder(ctx context.Context, tx interface{}, userID string) (interface{}, error)
 }

--- a/presentation/controller/transaction.go
+++ b/presentation/controller/transaction.go
@@ -17,6 +17,7 @@ type (
 		HookTransaction(ctx *gin.Context)
 		GetAllTransactionsWithPagination(ctx *gin.Context)
 		GetTransactionByID(ctx *gin.Context)
+		GetNextOrder(ctx *gin.Context)
 	}
 
 	transactionController struct {
@@ -102,5 +103,19 @@ func (t transactionController) GetTransactionByID(ctx *gin.Context) {
 	}
 
 	res := presentation.BuildResponseSuccess(message.SuccessGetTransaction, result)
+	ctx.JSON(http.StatusOK, res)
+}
+
+func (t transactionController) GetNextOrder(ctx *gin.Context) {
+	userID := ctx.MustGet("user_id").(string)
+
+	result, err := t.transactionService.GetNextOrder(ctx.Request.Context(), userID)
+	if err != nil {
+		res := presentation.BuildResponseFailed(message.FailedGetNextOrder, err.Error(), nil)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, res)
+		return
+	}
+
+	res := presentation.BuildResponseSuccess(message.SuccessGetNextOrder, result)
 	ctx.JSON(http.StatusOK, res)
 }

--- a/presentation/message/transaction.go
+++ b/presentation/message/transaction.go
@@ -5,9 +5,11 @@ const (
 	FailedHookTransaction    = "failed hook transaction"
 	FailedGetAllTransactions = "failed get transactions"
 	FailedGetTransaction     = "failed get transaction"
+	FailedGetNextOrder       = "failed get next order"
 
 	SuccessCreateTransaction  = "success create transaction"
 	SuccessHookTransaction    = "success hook transaction"
 	SuccessGetAllTransactions = "success get transactions"
 	SuccessGetTransaction     = "success get transaction"
+	SuccessGetNextOrder       = "success get next order"
 )

--- a/presentation/route/transaction.go
+++ b/presentation/route/transaction.go
@@ -15,5 +15,8 @@ func TransactionRoute(route *gin.Engine, transactionController controller.Transa
 		transactionGroup.GET("/", middleware.Authenticate(jwtService), transactionController.GetAllTransactionsWithPagination)
 		transactionGroup.GET("/:id", middleware.Authenticate(jwtService), transactionController.GetTransactionByID)
 		transactionGroup.POST("/hook", transactionController.HookTransaction)
+
+		// Kitchen
+		transactionGroup.GET("/next-order", middleware.Authenticate(jwtService), transactionController.GetNextOrder)
 	}
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve the "next order" for a user in a transaction system. The changes span multiple layers of the application, including the response models, service layer, repository layer, controller, and routing. Below is a summary of the most important changes grouped by theme.

### Feature Implementation: "Next Order" Retrieval

* **Response Model Update**: Added a new `NextOrder` struct to the `response/transaction.go` file to represent the data structure for the next order, including `QueueCode` and a list of `OrderForTransaction`. (`[application/response/transaction.goR40-R44](diffhunk://#diff-7581f0628aff1fe984c1bb355d81d8b2fe207548db2d1164f818d60c0a4d8872R40-R44)`)

* **Service Layer Update**: Introduced the `GetNextOrder` method in the `transaction_service.go` file to fetch the next pending order for a user. This includes logic to retrieve data from the repository, map it to the response model, and handle errors. (`[[1]](diffhunk://#diff-0b7892c219135bcefa2ca365debe985a4cafd10a601eee3e0425055536c95915R29)`, `[[2]](diffhunk://#diff-0b7892c219135bcefa2ca365debe985a4cafd10a601eee3e0425055536c95915R320-R352)`)

* **Repository Layer Update**: Added the `GetNextOrder` method to the `transaction/repository.go` and implemented it in `transaction.go` to query the database for the next pending order based on user ID, payment status, and order status. (`[[1]](diffhunk://#diff-7595c3661860df61edbb833a461f225b40b12578a393228272490733c9839f86R14)`, `[[2]](diffhunk://#diff-71f0bbd63b1a65be3ca705b3b9db040b7211face54b12779f23c4ddcae49e994R179-R207)`)

### Controller and Routing

* **Controller Update**: Added the `GetNextOrder` method in `transaction_controller.go` to handle HTTP requests for the next order, invoking the service layer and returning appropriate responses. (`[[1]](diffhunk://#diff-ef5ab5b64be0e338e8f6533b559758997e51952e3a2d59162c24f0c89169fd25R20)`, `[[2]](diffhunk://#diff-ef5ab5b64be0e338e8f6533b559758997e51952e3a2d59162c24f0c89169fd25R108-R121)`)

* **Route Update**: Registered a new route `/next-order` in `transaction.go` to expose the "Get Next Order" functionality via an authenticated GET request. (`[presentation/route/transaction.goR18-R20](diffhunk://#diff-477299793cc01d92f18c3e95e4da53a2e056922db03a49bb9b8224865f5f8c11R18-R20)`)

### Messaging

* **Message Constants**: Added success and failure message constants for the "Get Next Order" operation in `transaction.go`. (`[presentation/message/transaction.goR8-R14](diffhunk://#diff-cb185d3689bcc70c65548ce3885624e0314147b1c81fa0abb00587e095688ab5R8-R14)`)