### PR TITLE
feat: add order status validation to transaction cooking and delivering processes

### DIFF
--- a/application/service/transaction_service.go
+++ b/application/service/transaction_service.go
@@ -430,6 +430,10 @@ func (s *transactionService) StartCooking(ctx context.Context, req request.Start
 		return response.StartCooking{}, transaction.ErrorInvalidTransaction
 	}
 
+	if transactionSchema.OrderStatus != transaction.OrderStatusPending {
+		return response.StartCooking{}, transaction.ErrorInvalidOrderStatus
+	}
+
 	_, err = s.transactionRepository.UpdateTransactionCookingStatusStart(ctx, tx, transactionSchema.ID.String())
 	if err != nil {
 		return response.StartCooking{}, err
@@ -473,6 +477,10 @@ func (s *transactionService) FinishCooking(ctx context.Context, req request.Fini
 		return response.FinishCooking{}, transaction.ErrorInvalidTransaction
 	}
 
+	if transactionSchema.OrderStatus != transaction.OrderStatusPreparing {
+		return response.FinishCooking{}, transaction.ErrorInvalidOrderStatus
+	}
+
 	_, err = s.transactionRepository.UpdateTransactionCookingStatusFinish(ctx, nil, transactionSchema.ID.String())
 	if err != nil {
 		return response.FinishCooking{}, err
@@ -509,6 +517,10 @@ func (s *transactionService) StartDelivering(ctx context.Context, req request.St
 	transactionSchema, ok := retrievedData.(schema.Transaction)
 	if !ok {
 		return response.StartDelivering{}, transaction.ErrorInvalidTransaction
+	}
+
+	if transactionSchema.OrderStatus != transaction.OrderStatusReadyToServe {
+		return response.StartDelivering{}, transaction.ErrorInvalidOrderStatus
 	}
 
 	_, err = s.transactionRepository.UpdateTransactionDeliveringStatusStart(ctx, nil, transactionSchema.ID.String())
@@ -564,6 +576,10 @@ func (s *transactionService) FinishDelivering(ctx context.Context, req request.F
 	transactionSchema, ok := retrievedData.(schema.Transaction)
 	if !ok {
 		return response.FinishDelivering{}, transaction.ErrorInvalidTransaction
+	}
+
+	if transactionSchema.OrderStatus != transaction.OrderStatusDelivering {
+		return response.FinishDelivering{}, transaction.ErrorInvalidOrderStatus
 	}
 
 	_, err = s.transactionRepository.UpdateTransactionDeliveringStatusFinish(ctx, nil, transactionSchema.ID.String())

--- a/domain/transaction/error.go
+++ b/domain/transaction/error.go
@@ -7,4 +7,5 @@ import (
 var (
 	ErrorInvalidTransaction = errors.New("invalid transaction")
 	ErrorGetAllTransactions = errors.New("failed to get all transactions")
+	ErrorInvalidOrderStatus = errors.New("invalid order status")
 )


### PR DESCRIPTION
This pull request introduces stricter validation for order status transitions in the `transactionService` methods to ensure that operations like starting or finishing cooking and delivering are only performed when the order is in the correct state. Additionally, a new error type has been added to handle invalid order statuses.

### Validation Enhancements for Order Status Transitions:
* Added checks in `StartCooking` to ensure the order status is `OrderStatusPending` before proceeding. (`application/service/transaction_service.go`, [application/service/transaction_service.goR433-R436](diffhunk://#diff-0b7892c219135bcefa2ca365debe985a4cafd10a601eee3e0425055536c95915R433-R436))
* Added checks in `FinishCooking` to ensure the order status is `OrderStatusPreparing` before proceeding. (`application/service/transaction_service.go`, [application/service/transaction_service.goR480-R483](diffhunk://#diff-0b7892c219135bcefa2ca365debe985a4cafd10a601eee3e0425055536c95915R480-R483))
* Added checks in `StartDelivering` to ensure the order status is `OrderStatusReadyToServe` before proceeding. (`application/service/transaction_service.go`, [application/service/transaction_service.goR522-R525](diffhunk://#diff-0b7892c219135bcefa2ca365debe985a4cafd10a601eee3e0425055536c95915R522-R525))
* Added checks in `FinishDelivering` to ensure the order status is `OrderStatusDelivering` before proceeding. (`application/service/transaction_service.go`, [application/service/transaction_service.goR581-R584](diffhunk://#diff-0b7892c219135bcefa2ca365debe985a4cafd10a601eee3e0425055536c95915R581-R584))

### Error Handling Improvements:
* Introduced a new error type `ErrorInvalidOrderStatus` to handle cases where the order status does not match the expected state. (`domain/transaction/error.go`, [domain/transaction/error.goR10](diffhunk://#diff-c0ae557d7bfab9c7471f93fc8d9c65bd2a69a33af7ed09eb76f5a5efc0d7c8d1R10))