### PR TITLE
test: enhance unit tests for transaction services by integrating order domain service and improving mock implementations

### DIFF
--- a/test/start_cooking_test.go
+++ b/test/start_cooking_test.go
@@ -24,9 +24,13 @@ type MockTransactionRepositoryForStartCooking struct {
 	mock.Mock
 }
 
-func (m *MockTransactionRepositoryForStartCooking) GetTransactionByQueueCode(ctx context.Context, tx interface{}, queueCode string) (interface{}, error) {
+func (m *MockTransactionRepositoryForStartCooking) GetTransactionByQueueCode(ctx context.Context, tx interface{}, queueCode string) (transaction.Query, error) {
 	args := m.Called(ctx, tx, queueCode)
-	return args.Get(0), args.Error(1)
+	return args.Get(0).(transaction.Query), args.Error(1)
+}
+
+func (m *MockTransactionRepositoryForStartCooking) GetDetailedTransactionByID(ctx context.Context, tx interface{}, id string) (transaction.Query, error) {
+	return transaction.Query{}, nil
 }
 
 func (m *MockTransactionRepositoryForStartCooking) UpdateTransactionCookingStatusStart(ctx context.Context, tx interface{}, transactionID string) (transaction.Transaction, error) {
@@ -160,6 +164,7 @@ func TestStartCooking_Success(t *testing.T) {
 		mockTableRepo,
 		mockOrderRepo,
 		mockMenuRepo,
+		nil,
 		mockPaymentGateway,
 		mockTransactionInterface,
 		nil,
@@ -192,6 +197,7 @@ func TestStartCooking_TransactionNotFound(t *testing.T) {
 		mockTableRepo,
 		mockOrderRepo,
 		mockMenuRepo,
+		nil,
 		mockPaymentGateway,
 		mockTransactionInterface,
 		nil,
@@ -224,6 +230,7 @@ func TestStartCooking_InvalidTransactionType(t *testing.T) {
 		mockTableRepo,
 		mockOrderRepo,
 		mockMenuRepo,
+		nil,
 		mockPaymentGateway,
 		mockTransactionInterface,
 		nil,
@@ -256,6 +263,7 @@ func TestStartCooking_InvalidOrderStatus(t *testing.T) {
 		mockTableRepo,
 		mockOrderRepo,
 		mockMenuRepo,
+		nil,
 		mockPaymentGateway,
 		mockTransactionInterface,
 		nil,
@@ -288,6 +296,7 @@ func TestStartCooking_GetTransactionError(t *testing.T) {
 		mockTableRepo,
 		mockOrderRepo,
 		mockMenuRepo,
+		nil,
 		mockPaymentGateway,
 		mockTransactionInterface,
 		nil,
@@ -320,6 +329,7 @@ func TestStartCooking_UpdateStatusError(t *testing.T) {
 		mockTableRepo,
 		mockOrderRepo,
 		mockMenuRepo,
+		nil,
 		mockPaymentGateway,
 		mockTransactionInterface,
 		nil,
@@ -352,6 +362,7 @@ func TestStartCooking_WithMultipleOrders(t *testing.T) {
 		mockTableRepo,
 		mockOrderRepo,
 		mockMenuRepo,
+		nil,
 		mockPaymentGateway,
 		mockTransactionInterface,
 		nil,


### PR DESCRIPTION
```
 go test ./test/... -v
=== RUN   TestCalculateTotalPrice_Success
--- PASS: TestCalculateTotalPrice_Success (0.00s)
=== RUN   TestCalculateTotalPrice_SingleItem
--- PASS: TestCalculateTotalPrice_SingleItem (0.00s)
=== RUN   TestCalculateTotalPrice_ZeroQuantity
--- PASS: TestCalculateTotalPrice_ZeroQuantity (0.00s)
=== RUN   TestCalculateTotalPrice_NegativeQuantity
--- PASS: TestCalculateTotalPrice_NegativeQuantity (0.00s)
=== RUN   TestCalculateTotalPrice_MenuNotFound
--- PASS: TestCalculateTotalPrice_MenuNotFound (0.00s)
=== RUN   TestCalculateTotalPrice_EmptyOrders
--- PASS: TestCalculateTotalPrice_EmptyOrders (0.00s)
=== RUN   TestCalculateTotalPrice_DecimalPrices
--- PASS: TestCalculateTotalPrice_DecimalPrices (0.00s)
=== RUN   TestCalculateTotalPrice_LargeQuantities
--- PASS: TestCalculateTotalPrice_LargeQuantities (0.00s)
=== RUN   TestCalculateTotalPrice_MixedValidAndInvalid
--- PASS: TestCalculateTotalPrice_MixedValidAndInvalid (0.00s)
=== RUN   TestCreateTransaction_Success
--- PASS: TestCreateTransaction_Success (0.00s)
=== RUN   TestFinishCooking_Success
--- PASS: TestFinishCooking_Success (0.00s)
=== RUN   TestFinishCooking_TransactionNotFound
--- PASS: TestFinishCooking_TransactionNotFound (0.00s)
=== RUN   TestFinishCooking_InvalidTransactionType
--- PASS: TestFinishCooking_InvalidTransactionType (0.00s)
=== RUN   TestFinishCooking_InvalidOrderStatus
--- PASS: TestFinishCooking_InvalidOrderStatus (0.00s)
=== RUN   TestFinishCooking_GetTransactionError
--- PASS: TestFinishCooking_GetTransactionError (0.00s)
=== RUN   TestFinishCooking_UpdateStatusError
--- PASS: TestFinishCooking_UpdateStatusError (0.00s)
=== RUN   TestFinishCooking_WithMultipleOrders
--- PASS: TestFinishCooking_WithMultipleOrders (0.00s)
=== RUN   TestFinishDelivering_Success
--- PASS: TestFinishDelivering_Success (0.00s)
=== RUN   TestFinishDelivering_TransactionNotFound
--- PASS: TestFinishDelivering_TransactionNotFound (0.00s)
=== RUN   TestFinishDelivering_InvalidTransactionType
--- PASS: TestFinishDelivering_InvalidTransactionType (0.00s)
=== RUN   TestFinishDelivering_InvalidOrderStatus
--- PASS: TestFinishDelivering_InvalidOrderStatus (0.00s)
=== RUN   TestFinishDelivering_UpdateStatusError
--- PASS: TestFinishDelivering_UpdateStatusError (0.00s)
=== RUN   TestFinishDelivering_UpdateServedAtError
--- PASS: TestFinishDelivering_UpdateServedAtError (0.00s)
=== RUN   TestFinishDelivering_TransactionBeginError
--- PASS: TestFinishDelivering_TransactionBeginError (0.00s)
=== RUN   TestFinishDelivering_WithMultipleOrders
--- PASS: TestFinishDelivering_WithMultipleOrders (0.00s)
=== RUN   TestGetAllTransactionsWithPagination_Success
--- PASS: TestGetAllTransactionsWithPagination_Success (0.00s)
=== RUN   TestGetAllTransactionsWithPagination_Empty
--- PASS: TestGetAllTransactionsWithPagination_Empty (0.00s)
=== RUN   TestGetAllTransactionsWithPagination_InvalidType
--- PASS: TestGetAllTransactionsWithPagination_InvalidType (0.00s)
=== RUN   TestGetAllTransactionsWithPagination_RepoError
--- PASS: TestGetAllTransactionsWithPagination_RepoError (0.00s)
=== RUN   TestGetNextOrder_Success
--- PASS: TestGetNextOrder_Success (0.00s)
=== RUN   TestGetNextOrder_NoOrder
--- PASS: TestGetNextOrder_NoOrder (0.00s)
=== RUN   TestGetNextOrder_InvalidType
--- PASS: TestGetNextOrder_InvalidType (0.00s)
=== RUN   TestGetNextOrder_RepoError
--- PASS: TestGetNextOrder_RepoError (0.00s)
=== RUN   TestGetAllReadyToServeTransactionList_Success
--- PASS: TestGetAllReadyToServeTransactionList_Success (0.00s)
=== RUN   TestGetAllReadyToServeTransactionList_Empty
--- PASS: TestGetAllReadyToServeTransactionList_Empty (0.00s)
=== RUN   TestGetAllReadyToServeTransactionList_InvalidType
--- PASS: TestGetAllReadyToServeTransactionList_InvalidType (0.00s)
=== RUN   TestGetTransactionByID_Success
--- PASS: TestGetTransactionByID_Success (0.00s)
=== RUN   TestGetTransactionByID_Success_NotDelayed
--- PASS: TestGetTransactionByID_Success_NotDelayed (0.00s)
=== RUN   TestGetTransactionByID_TransactionNotFound
--- PASS: TestGetTransactionByID_TransactionNotFound (0.00s)
=== RUN   TestGetTransactionByID_InvalidTransactionType
--- PASS: TestGetTransactionByID_InvalidTransactionType (0.00s)
=== RUN   TestGetTransactionByID_EmptyOrders
--- PASS: TestGetTransactionByID_EmptyOrders (0.00s)
=== RUN   TestGetTransactionByID_WithDecimalPrices
--- PASS: TestGetTransactionByID_WithDecimalPrices (0.00s)
=== RUN   TestStartCooking_Success
--- PASS: TestStartCooking_Success (0.00s)
=== RUN   TestStartCooking_TransactionNotFound
--- PASS: TestStartCooking_TransactionNotFound (0.00s)
=== RUN   TestStartCooking_InvalidTransactionType
--- PASS: TestStartCooking_InvalidTransactionType (0.00s)
=== RUN   TestStartCooking_InvalidOrderStatus
--- PASS: TestStartCooking_InvalidOrderStatus (0.00s)
=== RUN   TestStartCooking_GetTransactionError
--- PASS: TestStartCooking_GetTransactionError (0.00s)
=== RUN   TestStartCooking_UpdateStatusError
--- PASS: TestStartCooking_UpdateStatusError (0.00s)
=== RUN   TestStartCooking_WithMultipleOrders
--- PASS: TestStartCooking_WithMultipleOrders (0.00s)
=== RUN   TestStartDelivering_Success
--- PASS: TestStartDelivering_Success (0.00s)
=== RUN   TestStartDelivering_TransactionNotFound
--- PASS: TestStartDelivering_TransactionNotFound (0.00s)
=== RUN   TestStartDelivering_InvalidTransactionType
--- PASS: TestStartDelivering_InvalidTransactionType (0.00s)
=== RUN   TestStartDelivering_InvalidOrderStatus
--- PASS: TestStartDelivering_InvalidOrderStatus (0.00s)
=== RUN   TestStartDelivering_GetTransactionError
--- PASS: TestStartDelivering_GetTransactionError (0.00s)
=== RUN   TestStartDelivering_UpdateStatusError
--- PASS: TestStartDelivering_UpdateStatusError (0.00s)
=== RUN   TestStartDelivering_WithMultipleOrders
--- PASS: TestStartDelivering_WithMultipleOrders (0.00s)
=== RUN   TestUpdateMenuAvailability_Success_AvailableToUnavailable
--- PASS: TestUpdateMenuAvailability_Success_AvailableToUnavailable (0.00s)
=== RUN   TestUpdateMenuAvailability_Success_UnavailableToAvailable
--- PASS: TestUpdateMenuAvailability_Success_UnavailableToAvailable (0.00s)
=== RUN   TestUpdateMenuAvailability_Success_SameState
--- PASS: TestUpdateMenuAvailability_Success_SameState (0.00s)
=== RUN   TestUpdateMenuAvailability_MenuNotFound
--- PASS: TestUpdateMenuAvailability_MenuNotFound (0.00s)
=== RUN   TestUpdateMenuAvailability_CategoryNotFound
--- PASS: TestUpdateMenuAvailability_CategoryNotFound (0.00s)
=== RUN   TestUpdateMenuAvailability_RepositoryError
--- PASS: TestUpdateMenuAvailability_RepositoryError (0.00s)
=== RUN   TestUpdateMenuAvailability_WithDecimalPrice
--- PASS: TestUpdateMenuAvailability_WithDecimalPrice (0.00s)
=== RUN   TestUpdateMenuAvailability_StateTransitionValidation
=== RUN   TestUpdateMenuAvailability_StateTransitionValidation/Available_to_Unavailable
=== RUN   TestUpdateMenuAvailability_StateTransitionValidation/Unavailable_to_Available
=== RUN   TestUpdateMenuAvailability_StateTransitionValidation/Available_to_Available
=== RUN   TestUpdateMenuAvailability_StateTransitionValidation/Unavailable_to_Unavailable
--- PASS: TestUpdateMenuAvailability_StateTransitionValidation (0.00s)
    --- PASS: TestUpdateMenuAvailability_StateTransitionValidation/Available_to_Unavailable (0.00s)
    --- PASS: TestUpdateMenuAvailability_StateTransitionValidation/Unavailable_to_Available (0.00s)
    --- PASS: TestUpdateMenuAvailability_StateTransitionValidation/Available_to_Available (0.00s)
    --- PASS: TestUpdateMenuAvailability_StateTransitionValidation/Unavailable_to_Unavailable (0.00s)
PASS
ok      fp-kpl/test     (cached)
```